### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 import helper for your app's plugin.
 
 
-[![](https://pypip.in/v/plugin-loader/badge.svg)](https://pypi.python.org/pypi/plugin-loader/)
+[![](https://img.shields.io/pypi/v/plugin-loader.svg)](https://pypi.python.org/pypi/plugin-loader/)
 [![](https://pypip.in/egg/plugin-loader/badge.svg)](https://pypi.python.org/pypi/plugin-loader/)
-[![](https://pypip.in/wheel/plugin-loader/badge.svg)](https://pypi.python.org/pypi/plugin-loader/)
-[![](https://pypip.in/license/plugin-loader/badge.svg)](https://pypi.python.org/pypi/plugin-loader/)
+[![](https://img.shields.io/pypi/wheel/plugin-loader.svg)](https://pypi.python.org/pypi/plugin-loader/)
+[![](https://img.shields.io/pypi/l/plugin-loader.svg)](https://pypi.python.org/pypi/plugin-loader/)
 
 ## Install
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20plugin-loader))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `plugin-loader`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.